### PR TITLE
Only include endian.h if available. Fixes #4.

### DIFF
--- a/picohash.h
+++ b/picohash.h
@@ -26,7 +26,9 @@
 #define _PICOHASH_BIG_ENDIAN
 #endif
 #else               // ! defined __LITTLE_ENDIAN__
+#if __has_include("endian.h")
 #include <endian.h> // machine/endian.h
+#endif
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define _PICOHASH_BIG_ENDIAN
 #endif


### PR DESCRIPTION
`endian.h` is not available on Windows. Just not including it fixes the issue #4 in this case. This doesn't affect functionality in any way.